### PR TITLE
FIX for #1 Setup the ability to exclude paths/patterns

### DIFF
--- a/manifests/serverset.pp
+++ b/manifests/serverset.pp
@@ -1,5 +1,7 @@
 define clustersync::serverset (
   $servers,
+  $exclude      = [],
+  $auto         = undef,
   $key_source   = undef,
   $key_content  = undef,
   $csync2_template = 'clustersync/csync2_serverset.cfg.erb'

--- a/templates/csync2_serverset.cfg.erb
+++ b/templates/csync2_serverset.cfg.erb
@@ -9,5 +9,13 @@ group primary {
 	include <%= source_path %>;
 <%- end -%>
 
+<%- @exclude.sort.each do |exclude_alias| -%>
+	exclude <%= exclude_alias %>;
+<%- end -%>
+
+<%- if @auto -%>
+	auto <%= @auto %>;
+<%- end -%>
+
 	key /etc/csync2/csync2_<%= @title %>.key;
 }


### PR DESCRIPTION
Fix for issue #1 

Not only does this have the ability to exclude paths/patterns (via `exclude` parameter), but also added `auto` parameter to match `csync2` syntax) for the incorporation of automatic conflict resolution method. 
